### PR TITLE
removed streamimg sentense

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,8 +20,6 @@ Please respect copyright laws and terms of service when using this.
 
 **Social media:** Facebook, Instagram, Twitter/X, TikTok, Reddit, Snapchat, Pinterest, LinkedIn, Tumblr, VK, Bluesky, and more
 
-**Streaming:** Netflix, Disney+, HBO Max, Hulu, Amazon Prime Video, Peacock, Paramount+, Crunchyroll, Tubi, Pluto TV, and more
-
 **Live streaming:** Twitch, Kick, DLive, Trovo, and more
 
 **Music/Audio:** SoundCloud, Spotify, Deezer, Bandcamp, Audiomack, Mixcloud, and more


### PR DESCRIPTION
This pull request makes a minor update to the `.github/README.md` file by removing the list of streaming services from the documentation. This helps clarify the scope of supported platforms.

- Documentation update:
  * Removed the mention of specific streaming services (e.g., Netflix, Disney+, HBO Max, etc.) from the supported platforms list in `.github/README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Supported sites list, excluding streaming services such as Netflix, Disney+, HBO Max, Hulu, Amazon Prime Video, Peacock, Paramount+, Crunchyroll, Tubi, and Pluto TV.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->